### PR TITLE
Bug fix issues related to the pagination query builder

### DIFF
--- a/src/api_configs/query.rs
+++ b/src/api_configs/query.rs
@@ -14,7 +14,7 @@ pub fn build_paging_query(limit: Option<i32>, after: Option<&str>) -> (String, b
     let limit_query = match limit {
         Some(limit) => {
             query_begun = true;
-            format!("?{}", limit)
+            format!("?limit={}", limit)
         }
         None => String::new(),
     };
@@ -23,7 +23,7 @@ pub fn build_paging_query(limit: Option<i32>, after: Option<&str>) -> (String, b
         Some(after) => {
             let query_check = query_begun_check(query_begun);
             query_begun = query_check.1;
-            format!("{}{}", query_check.0, after)
+            format!("{}after={}", query_check.0, after)
         }
         None => String::new(),
     };
@@ -44,8 +44,9 @@ pub fn build_query_string(
     let property_query = if properties.is_empty() {
         String::new()
     } else {
-        query_begun = true;
-        format!("?properties={}", properties.join(","))
+        let query_check = query_begun_check(query_begun);
+        query_begun = query_check.1;
+        format!("{}properties={}", query_check.0, properties.join(","))
     };
     let properties_with_history_query = if properties_with_history.is_empty() {
         String::new()


### PR DESCRIPTION
In the current implementation, keys `limit` and `after` are missing in the `build_paging_query` function, which caused the list API call always to return the first N results. In addition, the `build_query_string` function also appends an unchecked `?` to the query string, so when you pass the result of `build_paging_query` into this function, it creates a broken query string with one `?` sign got escaped.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/WORK180/hubspot-api/10)
<!-- Reviewable:end -->
