### PR TITLE
Bug fix issues related to the associations API

### DIFF
--- a/src/api_configs/associations.rs
+++ b/src/api_configs/associations.rs
@@ -37,11 +37,11 @@ pub struct AssociationTypes {
 #[derive(Serialize, Debug)]
 pub struct AssociationCreationDetails {
     /// Whether the association type was created by HubSpot or a user (HUBSPOT_DEFINED and USER_DEFINED)
-    #[serde(alias = "associationCategory")]
+    #[serde(rename = "associationCategory")]
     pub category: String,
     /// The numeric ID for that association type.
-    #[serde(alias = "associationTypeId")]
-    pub type_id: AssociationTypes,
+    #[serde(rename = "associationTypeId")]
+    pub type_id: i64,
 }
 
 /// A  Hubspot result type for a created association.
@@ -52,10 +52,10 @@ pub struct CreatedAssociationResult {
     pub from_object_type_id: String,
     /// The ID of the record to associate.
     #[serde(alias = "fromObjectId")]
-    pub from_object_id: String,
+    pub from_object_id: i64,
     /// The type of object you're associating the record to (e.g. company).
     #[serde(alias = "toObjectId")]
-    pub to_object_id: String,
+    pub to_object_id: i64,
     /// Association labels describe relationships between all standard CRM objects
     pub labels: Vec<String>,
 }

--- a/src/api_configs/mod.rs
+++ b/src/api_configs/mod.rs
@@ -5,6 +5,8 @@ pub mod types;
 
 use std::sync::Arc;
 
+pub use associations::{AssociationCreationDetails, AssociationTypes};
+
 pub use types::{
     AssociationLinks, AssociationType, CreateAssociation, HubspotRecord, OptionNotDesired,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,10 @@ mod engagements;
 mod objects;
 mod owners;
 
+pub mod associations {
+    pub use super::api_configs::{AssociationCreationDetails, AssociationTypes};
+}
+
 pub use api_configs::types;
 pub use engagements::notes;
 pub use engagements::EngagementType;


### PR DESCRIPTION
This pull request contains fixes for the following issues:
- Exported function `AssociationsApiCollection.create` requires private struct parameter `Vec<AssociationCreationDetails>`
- Type mismatch in `AssociationCreationDetails` and `CreatedAssociationResult`
- Incorrect use of serde attribute `alias` in `AssociationCreationDetails`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/WORK180/hubspot-api/11)
<!-- Reviewable:end -->
